### PR TITLE
deprecated v2 yaml package

### DIFF
--- a/file/config_import.go
+++ b/file/config_import.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aceld/kis-flow/flow"
 	"github.com/aceld/kis-flow/kis"
 	"github.com/aceld/kis-flow/metrics"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type allConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.14.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 


### PR DESCRIPTION
deprecated v2 yaml package in config_import.go, and in order to align project yaml package version